### PR TITLE
Use nameof

### DIFF
--- a/src/Microsoft.Azure.Relay/Common/TaskEx.cs
+++ b/src/Microsoft.Azure.Relay/Common/TaskEx.cs
@@ -250,7 +250,7 @@ namespace Microsoft.Azure.Relay
         {
             if (exception == null)
             {
-                throw RelayEventSource.Log.ArgumentNull("exception");
+                throw RelayEventSource.Log.ArgumentNull(nameof(exception));
             }
 
             var completionSource = new TaskCompletionSource<TResult>();

--- a/src/Microsoft.Azure.Relay/HybridConnectionListener.cs
+++ b/src/Microsoft.Azure.Relay/HybridConnectionListener.cs
@@ -43,12 +43,12 @@ namespace Microsoft.Azure.Relay
         {
             if (address == null || tokenProvider == null)
             {
-                throw RelayEventSource.Log.ThrowingException(new ArgumentNullException(address == null ? "address" : "tokenProvider"), this);
+                throw RelayEventSource.Log.ThrowingException(new ArgumentNullException(address == null ? nameof(address) : nameof(tokenProvider)), this);
             }
             else if (address.Scheme != RelayConstants.HybridConnectionScheme)
             {
                 throw RelayEventSource.Log.ThrowingException(
-                    new ArgumentException(SR.InvalidUriScheme.FormatInvariant(address.Scheme, RelayConstants.HybridConnectionScheme), "address"), this);
+                    new ArgumentException(SR.InvalidUriScheme.FormatInvariant(address.Scheme, RelayConstants.HybridConnectionScheme), nameof(address)), this);
             }
 
             this.Address = address;


### PR DESCRIPTION
`nameof` is already being used throughout this codebase. This PR cleans up the remaining cases where `nameof` could be used.