### PR TITLE
Fixed issue where converted value overflows where IP address starting from 128 or higher in "azure-relay-dotnet/samples/portbridge/PortBridge/IPRange.cs"

### DIFF
--- a/samples/portbridge/PortBridge/IPRange.cs
+++ b/samples/portbridge/PortBridge/IPRange.cs
@@ -44,8 +44,8 @@ namespace PortBridge
         long IPAddressToInt(IPAddress address)
         {
             byte[] ab = address.GetAddressBytes();
-            long result = ((ab[0] << 24) + (ab[1] << 16) + (ab[2] << 8) + ab[3]);
-            return result;
+			long result = (((long)ab[0] << 24) + ((long)ab[1] << 16) + ((long)ab[2] << 8) + ab[3]);
+			return result;
         }
     }
 }

--- a/samples/portbridge/PortBridge/IPRange.cs
+++ b/samples/portbridge/PortBridge/IPRange.cs
@@ -44,7 +44,7 @@ namespace PortBridge
         long IPAddressToInt(IPAddress address)
         {
             byte[] ab = address.GetAddressBytes();
-			long result = (((long)ab[0] << 24) + ((long)ab[1] << 16) + ((long)ab[2] << 8) + ab[3]);
+            long result = (((long)ab[0] << 24) + ((long)ab[1] << 16) + ((long)ab[2] << 8) + ab[3]);
 			return result;
         }
     }

--- a/samples/portbridge/PortBridge/IPRange.cs
+++ b/samples/portbridge/PortBridge/IPRange.cs
@@ -45,7 +45,7 @@ namespace PortBridge
         {
             byte[] ab = address.GetAddressBytes();
             long result = (((long)ab[0] << 24) + ((long)ab[1] << 16) + ((long)ab[2] << 8) + ab[3]);
-			return result;
+            return result;
         }
     }
 }


### PR DESCRIPTION
Hi,
I was checking out the samples and I have found an issue while defining firewall ip addresses range where  39.60.246.44 was not falling between 10.0.0.0 and 255.255.255.255. Going deeper into the code I  found that IPAddressToInt method in "azure-relay-dotnet/samples/portbridge/PortBridge/IPRange.cs" was returning wrong value on any ip address starting from 128 or higher. For example for 255.0.0.0 the returning value was -16777216 while the correct value is 4278190080.
The reason is that while left shifting a number by 24 it overflows for int. So I just typecast it as long. And it does not overflow and gives right output.

(it is my first ever contribution effort in any open source project. Please don't mind if I am getting anything wrong :) )

Thanks