### PR TITLE
Enable support for text frames 

### DIFF
--- a/src/Microsoft.Azure.Relay/HybridConnectionStream.cs
+++ b/src/Microsoft.Azure.Relay/HybridConnectionStream.cs
@@ -34,7 +34,6 @@ namespace Microsoft.Azure.Relay
             }
         }
 
-
         /// <summary>
         /// Initiates a graceful close process by shutting down sending through this 
         /// <see cref="HybridConnectionStream"/>. To disconnect cleanly and asynchronously, call ShutdownAsync,

--- a/src/Microsoft.Azure.Relay/HybridConnectionStream.cs
+++ b/src/Microsoft.Azure.Relay/HybridConnectionStream.cs
@@ -15,6 +15,12 @@ namespace Microsoft.Azure.Relay
     /// </summary>
     public abstract class HybridConnectionStream : Stream
     {
+
+        /// <summary>
+        /// Sets or gets the WriteMode for this stream. Default is WriteMode.Binary
+        /// </summary>
+        public WriteMode WriteMode { get; set; } = WriteMode.Binary;
+
         /// <summary>
         /// Initiates a graceful close process by shutting down sending through this 
         /// <see cref="HybridConnectionStream"/>. To disconnect cleanly and asynchronously, call Shutdown,
@@ -27,6 +33,7 @@ namespace Microsoft.Azure.Relay
                 this.ShutdownAsync(cts.Token).ConfigureAwait(false).GetAwaiter().GetResult();
             }
         }
+
 
         /// <summary>
         /// Initiates a graceful close process by shutting down sending through this 

--- a/src/Microsoft.Azure.Relay/HybridConnectionStream.cs
+++ b/src/Microsoft.Azure.Relay/HybridConnectionStream.cs
@@ -15,7 +15,6 @@ namespace Microsoft.Azure.Relay
     /// </summary>
     public abstract class HybridConnectionStream : Stream
     {
-
         /// <summary>
         /// Sets or gets the WriteMode for this stream. Default is WriteMode.Binary
         /// </summary>

--- a/src/Microsoft.Azure.Relay/WebSocketStream.cs
+++ b/src/Microsoft.Azure.Relay/WebSocketStream.cs
@@ -130,7 +130,7 @@ namespace Microsoft.Azure.Relay
                 {
                     WebSocketReceiveResult result = await this.webSocket.ReceiveAsync(
                         new ArraySegment<byte>(buffer, offset, count), linkedCancelSource.Token).ConfigureAwait(false);
-                    return result.Count;
+                    return result.Count; 
                 }
             }
             catch (WebSocketException webSocketException)
@@ -190,7 +190,7 @@ namespace Microsoft.Azure.Relay
                 using (var linkedCancelSource = CancellationTokenSource.CreateLinkedTokenSource(timeoutCancelSource.Token, cancelToken))
                 {
                     await this.webSocket.SendAsync(
-                        new ArraySegment<byte>(buffer, offset, count), WebSocketMessageType.Binary, true, linkedCancelSource.Token).ConfigureAwait(false);
+                        new ArraySegment<byte>(buffer, offset, count), this.WriteMode == WriteMode.Binary? WebSocketMessageType.Binary : WebSocketMessageType.Text, true, linkedCancelSource.Token).ConfigureAwait(false);
                 }
             }
             catch (WebSocketException webSocketException)
@@ -198,6 +198,7 @@ namespace Microsoft.Azure.Relay
                 throw RelayEventSource.Log.ThrowingException(WebSocketExceptionHelper.ConvertToRelayContract(webSocketException), this);
             }
         }
+
 
         public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
         {

--- a/src/Microsoft.Azure.Relay/WebSocketStream.cs
+++ b/src/Microsoft.Azure.Relay/WebSocketStream.cs
@@ -130,7 +130,7 @@ namespace Microsoft.Azure.Relay
                 {
                     WebSocketReceiveResult result = await this.webSocket.ReceiveAsync(
                         new ArraySegment<byte>(buffer, offset, count), linkedCancelSource.Token).ConfigureAwait(false);
-                    return result.Count; 
+                    return result.Count;
                 }
             }
             catch (WebSocketException webSocketException)
@@ -190,7 +190,7 @@ namespace Microsoft.Azure.Relay
                 using (var linkedCancelSource = CancellationTokenSource.CreateLinkedTokenSource(timeoutCancelSource.Token, cancelToken))
                 {
                     await this.webSocket.SendAsync(
-                        new ArraySegment<byte>(buffer, offset, count), this.WriteMode == WriteMode.Binary? WebSocketMessageType.Binary : WebSocketMessageType.Text, true, linkedCancelSource.Token).ConfigureAwait(false);
+                        new ArraySegment<byte>(buffer, offset, count), this.WriteMode == WriteMode.Binary ? WebSocketMessageType.Binary : WebSocketMessageType.Text, true, linkedCancelSource.Token).ConfigureAwait(false);
                 }
             }
             catch (WebSocketException webSocketException)

--- a/src/Microsoft.Azure.Relay/WriteMode.cs
+++ b/src/Microsoft.Azure.Relay/WriteMode.cs
@@ -1,0 +1,17 @@
+﻿namespace Microsoft.Azure.Relay
+{
+    /// <summary>
+    /// WriteMode options for HybridConnectionStream
+    /// </summary>
+    public enum WriteMode
+    {
+        /// <summary>
+        /// Write Binary frames on the WebSocket
+        /// </summary>
+        Binary,
+        /// <summary>
+        /// Write Text Frames on the WebSocket
+        /// </summary>
+        Text
+    }
+}

--- a/src/Microsoft.Azure.Relay/WriteMode.cs
+++ b/src/Microsoft.Azure.Relay/WriteMode.cs
@@ -6,12 +6,12 @@
     public enum WriteMode
     {
         /// <summary>
-        /// Write Binary frames on the WebSocket
-        /// </summary>
-        Binary,
-        /// <summary>
         /// Write Text Frames on the WebSocket
         /// </summary>
-        Text
+        Text = 0,
+        /// <summary>
+        /// Write Binary frames on the WebSocket
+        /// </summary>
+        Binary = 1
     }
 }


### PR DESCRIPTION
Enable support for text frames by allowing selection of a write mode of the HybridConnectionStream object. 