### PR TITLE
[Integrate from OneBranch] Make JSON serialization compatible with .NET Core

### DIFF
--- a/src/Microsoft.Azure.Relay/ListenerCommand.cs
+++ b/src/Microsoft.Azure.Relay/ListenerCommand.cs
@@ -5,6 +5,7 @@
 namespace Microsoft.Azure.Relay
 {
     using System;
+    using System.Collections.Generic;
     using System.IO;
     using System.Net;
     using System.Runtime.Serialization;
@@ -40,7 +41,7 @@ namespace Microsoft.Azure.Relay
     class ListenerCommand
     {
         [IgnoreDataMember]
-        static readonly DataContractJsonSerializer serializer = new DataContractJsonSerializer(typeof(ListenerCommand));
+        static readonly DataContractJsonSerializer serializer = new DataContractJsonSerializer(typeof(ListenerCommand), new DataContractJsonSerializerSettings { UseSimpleDictionaryFormat = true });
 
         [DataMember(Name = "accept", EmitDefaultValue = false)]
         public AcceptCommand Accept { get; set; }
@@ -91,29 +92,19 @@ namespace Microsoft.Azure.Relay
             public string Id { get; set; }
 
             [DataMember(Name = "connectHeaders", Order = 2)]
-            WebHeaderCollectionSerializer connectHeaders;
+            IDictionary<string, string> connectHeaders;
 
-            public WebHeaderCollection ConnectHeaders
+            [IgnoreDataMember]
+            public IDictionary<string, string> ConnectHeaders
             {
                 get
                 {
                     if (this.connectHeaders == null)
                     {
-                        this.connectHeaders = new WebHeaderCollectionSerializer(new WebHeaderCollection());
+                        this.connectHeaders = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
                     }
 
-                    return this.connectHeaders.WebHeaderCollection;
-                }
-                set
-                {
-                    if (value == null)
-                    {
-                        this.connectHeaders = null;
-                    }
-                    else
-                    {
-                        this.connectHeaders = new WebHeaderCollectionSerializer(value);
-                    }
+                    return this.connectHeaders;
                 }
             }
         }
@@ -149,43 +140,5 @@ namespace Microsoft.Azure.Relay
             public TimeSpan Delay { get; set; }
         }
 #endif // DEBUG
-
-        /// <summary>
-        /// Does some custom serialization to avoid having "Key": and "Value": entries for every single Http Header in the resulting JSON
-        /// </summary>
-        [Serializable]
-        class WebHeaderCollectionSerializer : ISerializable
-        {
-            public WebHeaderCollectionSerializer(WebHeaderCollection webHeaderCollection)
-            {
-                this.WebHeaderCollection = webHeaderCollection;
-            }
-
-            protected WebHeaderCollectionSerializer(SerializationInfo info, StreamingContext context)
-            {
-                this.WebHeaderCollection = new WebHeaderCollection();
-
-                // We don't know the names of all the HTTP headers so we simply enumerate whatever was serialized.
-                foreach (var item in info)
-                {
-                    var name = item.Name;
-                    var value = item.Value != null ? item.Value.ToString() : string.Empty;
-                    this.WebHeaderCollection.Add(name, value);
-                }
-            }
-
-            internal WebHeaderCollection WebHeaderCollection
-            {
-                get; private set;
-            }
-
-            void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
-            {
-                foreach (string key in this.WebHeaderCollection.Keys)
-                {
-                    info.AddValue(key, this.WebHeaderCollection[key]);
-                }
-            }
-        }
     }
 }


### PR DESCRIPTION
Make the ListenerCommand.AcceptCommand serialize to JSON (in the same wire format) using a mechanism that will work in .NET Core where ISerializable is not supported.