### PR TITLE
Update source file headers to mention MIT/license

### DIFF
--- a/src/Microsoft.Azure.Relay/AuthorizationFailedException.cs
+++ b/src/Microsoft.Azure.Relay/AuthorizationFailedException.cs
@@ -1,6 +1,5 @@
-﻿//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Azure.Relay
 {

--- a/src/Microsoft.Azure.Relay/Common/AsyncLock.cs
+++ b/src/Microsoft.Azure.Relay/Common/AsyncLock.cs
@@ -1,6 +1,5 @@
-﻿//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Azure.Relay
 {

--- a/src/Microsoft.Azure.Relay/Common/ExceptionExtensions.cs
+++ b/src/Microsoft.Azure.Relay/Common/ExceptionExtensions.cs
@@ -1,6 +1,5 @@
-﻿//-----------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//-----------------------------------------------------------------------------
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Azure.Relay
 {

--- a/src/Microsoft.Azure.Relay/Common/Fx.cs
+++ b/src/Microsoft.Azure.Relay/Common/Fx.cs
@@ -1,6 +1,5 @@
-﻿//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Azure.Relay
 {

--- a/src/Microsoft.Azure.Relay/Common/InputQueue.cs
+++ b/src/Microsoft.Azure.Relay/Common/InputQueue.cs
@@ -1,6 +1,5 @@
-//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Azure.Relay
 {

--- a/src/Microsoft.Azure.Relay/Common/SecurityToken.cs
+++ b/src/Microsoft.Azure.Relay/Common/SecurityToken.cs
@@ -1,6 +1,5 @@
-﻿//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Azure.Relay
 {

--- a/src/Microsoft.Azure.Relay/Common/SharedAccessSignatureTokenProvider.cs
+++ b/src/Microsoft.Azure.Relay/Common/SharedAccessSignatureTokenProvider.cs
@@ -1,6 +1,5 @@
-﻿//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Azure.Relay
 {

--- a/src/Microsoft.Azure.Relay/Common/StringExtensions.cs
+++ b/src/Microsoft.Azure.Relay/Common/StringExtensions.cs
@@ -1,6 +1,5 @@
-﻿//-----------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//-----------------------------------------------------------------------------
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Azure.Relay
 {

--- a/src/Microsoft.Azure.Relay/Common/TimeoutHelper.cs
+++ b/src/Microsoft.Azure.Relay/Common/TimeoutHelper.cs
@@ -1,6 +1,5 @@
-﻿//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Azure.Relay
 {

--- a/src/Microsoft.Azure.Relay/Common/TokenProvider.cs
+++ b/src/Microsoft.Azure.Relay/Common/TokenProvider.cs
@@ -1,6 +1,5 @@
-﻿//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Azure.Relay
 {

--- a/src/Microsoft.Azure.Relay/Common/TrackingContext.cs
+++ b/src/Microsoft.Azure.Relay/Common/TrackingContext.cs
@@ -1,6 +1,5 @@
-﻿//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Azure.Relay
 {

--- a/src/Microsoft.Azure.Relay/Common/UriHelper.cs
+++ b/src/Microsoft.Azure.Relay/Common/UriHelper.cs
@@ -1,6 +1,5 @@
-﻿//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Azure.Relay
 {

--- a/src/Microsoft.Azure.Relay/ConnectionLostException.cs
+++ b/src/Microsoft.Azure.Relay/ConnectionLostException.cs
@@ -1,6 +1,5 @@
-﻿//-----------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//-----------------------------------------------------------------------------
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Azure.Relay
 {

--- a/src/Microsoft.Azure.Relay/EndpointAlreadyExistsException.cs
+++ b/src/Microsoft.Azure.Relay/EndpointAlreadyExistsException.cs
@@ -1,6 +1,5 @@
-﻿//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Azure.Relay
 {

--- a/src/Microsoft.Azure.Relay/EndpointNotFoundException.cs
+++ b/src/Microsoft.Azure.Relay/EndpointNotFoundException.cs
@@ -1,6 +1,5 @@
-﻿//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Azure.Relay
 {

--- a/src/Microsoft.Azure.Relay/HybridConnectionClient.cs
+++ b/src/Microsoft.Azure.Relay/HybridConnectionClient.cs
@@ -1,6 +1,5 @@
-﻿//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Azure.Relay
 {

--- a/src/Microsoft.Azure.Relay/HybridConnectionConstants.cs
+++ b/src/Microsoft.Azure.Relay/HybridConnectionConstants.cs
@@ -1,6 +1,5 @@
-﻿//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Azure.Relay
 {

--- a/src/Microsoft.Azure.Relay/HybridConnectionListener.cs
+++ b/src/Microsoft.Azure.Relay/HybridConnectionListener.cs
@@ -1,6 +1,5 @@
-﻿//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Azure.Relay
 {

--- a/src/Microsoft.Azure.Relay/HybridConnectionRuntimeInformation.cs
+++ b/src/Microsoft.Azure.Relay/HybridConnectionRuntimeInformation.cs
@@ -1,6 +1,5 @@
-﻿//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Azure.Relay
 {

--- a/src/Microsoft.Azure.Relay/HybridConnectionStream.cs
+++ b/src/Microsoft.Azure.Relay/HybridConnectionStream.cs
@@ -1,6 +1,5 @@
-﻿//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Azure.Relay
 {

--- a/src/Microsoft.Azure.Relay/IConnectionStatus.cs
+++ b/src/Microsoft.Azure.Relay/IConnectionStatus.cs
@@ -1,6 +1,5 @@
-﻿//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Azure.Relay
 {

--- a/src/Microsoft.Azure.Relay/ListenerCommand.cs
+++ b/src/Microsoft.Azure.Relay/ListenerCommand.cs
@@ -1,6 +1,5 @@
-﻿//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Azure.Relay
 {

--- a/src/Microsoft.Azure.Relay/ManagementOperations.cs
+++ b/src/Microsoft.Azure.Relay/ManagementOperations.cs
@@ -1,6 +1,5 @@
-﻿//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Azure.Relay
 {

--- a/src/Microsoft.Azure.Relay/QuotaExceededException.cs
+++ b/src/Microsoft.Azure.Relay/QuotaExceededException.cs
@@ -1,6 +1,5 @@
-﻿//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Azure.Relay
 {

--- a/src/Microsoft.Azure.Relay/RelayConnectionStringBuilder.cs
+++ b/src/Microsoft.Azure.Relay/RelayConnectionStringBuilder.cs
@@ -1,6 +1,5 @@
-﻿//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Azure.Relay
 {

--- a/src/Microsoft.Azure.Relay/RelayConstants.cs
+++ b/src/Microsoft.Azure.Relay/RelayConstants.cs
@@ -1,6 +1,5 @@
-﻿//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Azure.Relay
 {

--- a/src/Microsoft.Azure.Relay/RelayEventSource.cs
+++ b/src/Microsoft.Azure.Relay/RelayEventSource.cs
@@ -1,6 +1,5 @@
-﻿//-----------------------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//-----------------------------------------------------------------------------
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Azure.Relay
 {

--- a/src/Microsoft.Azure.Relay/RelayException.cs
+++ b/src/Microsoft.Azure.Relay/RelayException.cs
@@ -1,6 +1,5 @@
-﻿//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Azure.Relay
 {

--- a/src/Microsoft.Azure.Relay/SR.cs
+++ b/src/Microsoft.Azure.Relay/SR.cs
@@ -1,6 +1,5 @@
-﻿//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Azure.Relay
 {

--- a/src/Microsoft.Azure.Relay/ServerBusyException.cs
+++ b/src/Microsoft.Azure.Relay/ServerBusyException.cs
@@ -1,6 +1,5 @@
-﻿//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Azure.Relay
 {

--- a/src/Microsoft.Azure.Relay/TokenRenewer.cs
+++ b/src/Microsoft.Azure.Relay/TokenRenewer.cs
@@ -1,6 +1,5 @@
-﻿//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Azure.Relay
 {

--- a/src/Microsoft.Azure.Relay/WebSocketExceptionHelper.cs
+++ b/src/Microsoft.Azure.Relay/WebSocketExceptionHelper.cs
@@ -1,6 +1,5 @@
-﻿//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Azure.Relay
 {

--- a/src/Microsoft.Azure.Relay/WebSocketStream.cs
+++ b/src/Microsoft.Azure.Relay/WebSocketStream.cs
@@ -1,6 +1,5 @@
-﻿//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Azure.Relay
 {

--- a/src/Microsoft.Azure.Relay/WebSockets/Net45/ClientWebSocket.cs
+++ b/src/Microsoft.Azure.Relay/WebSockets/Net45/ClientWebSocket.cs
@@ -1,6 +1,5 @@
-﻿//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Azure.Relay.WebSockets
 {
@@ -8,14 +7,13 @@ namespace Microsoft.Azure.Relay.WebSockets
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using System.Diagnostics.Contracts;
-    using System.Linq;
     using System.Net;
     using System.Net.WebSockets;
     using System.Security.Cryptography.X509Certificates;
-    using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
 
+    // From: https://referencesource.microsoft.com/#System/net/System/Net/WebSockets/ClientWebSocket.cs
     sealed class ClientWebSocket : WebSocket
     {
         private readonly ClientWebSocketOptions options;

--- a/src/Microsoft.Azure.Relay/WebSockets/Net45/Internal.cs
+++ b/src/Microsoft.Azure.Relay/WebSockets/Net45/Internal.cs
@@ -1,11 +1,9 @@
-﻿//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Azure.Relay.WebSockets
 {
-    using System;
-
+    // From: https://referencesource.microsoft.com/#System/net/System/Net/Internal.cs
     //
     // this class contains known header names
     //

--- a/src/Microsoft.Azure.Relay/WebSockets/Net45/Logging.cs
+++ b/src/Microsoft.Azure.Relay/WebSockets/Net45/Logging.cs
@@ -1,6 +1,5 @@
-﻿//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Azure.Relay.WebSockets
 {
@@ -10,7 +9,8 @@ namespace Microsoft.Azure.Relay.WebSockets
     using System.Security;
     using System.Globalization;
     using System.Diagnostics.CodeAnalysis;
-
+    
+    // From: https://referencesource.microsoft.com/#System/net/System/Net/Logging.cs
     internal class Logging
     {
         private static volatile bool s_LoggingEnabled = true;

--- a/src/Microsoft.Azure.Relay/WebSockets/Net45/SR.cs
+++ b/src/Microsoft.Azure.Relay/WebSockets/Net45/SR.cs
@@ -1,6 +1,5 @@
-﻿//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Azure.Relay.WebSockets
 {

--- a/src/Microsoft.Azure.Relay/WebSockets/Net45/WebSocketBuffer.cs
+++ b/src/Microsoft.Azure.Relay/WebSockets/Net45/WebSocketBuffer.cs
@@ -1,6 +1,5 @@
-﻿//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Azure.Relay.WebSockets
 {
@@ -9,6 +8,7 @@ namespace Microsoft.Azure.Relay.WebSockets
     using System.Globalization;
     using System.Runtime.InteropServices;
 
+    // From: https://referencesource.microsoft.com/#System/net/System/Net/WebSockets/WebSocketBuffer.cs
     // This class helps to abstract the internal WebSocket buffer, which is used to interact with the native WebSocket
     // protocol component (WSPC). It helps to shield the details of the layout and the involved pointer arithmetic.
     // The internal WebSocket buffer also contains a segment, which is used by the WebSocketBase class to buffer 

--- a/src/Microsoft.Azure.Relay/WebSockets/Net45/WebSocketHelpers.cs
+++ b/src/Microsoft.Azure.Relay/WebSockets/Net45/WebSocketHelpers.cs
@@ -1,24 +1,18 @@
-﻿//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Azure.Relay.WebSockets
 {
     using System;
-    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using System.Diagnostics.Contracts;
     using System.Globalization;
-    using System.IO;
     using System.Runtime.CompilerServices;
     using System.Security.Cryptography;
     using System.Text;
-    using System.Threading;
     using System.Threading.Tasks;
-    using Microsoft.Win32;
-    using System.Net.WebSockets;
-    using System.Net;
 
+    // From: https://referencesource.microsoft.com/#System/net/System/Net/WebSockets/WebSocketHelpers.cs
     internal static class WebSocketHelpers
     {
         internal const string SecWebSocketKeyGuid = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";

--- a/src/Microsoft.Azure.Relay/WriteMode.cs
+++ b/src/Microsoft.Azure.Relay/WriteMode.cs
@@ -1,6 +1,5 @@
-﻿//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Azure.Relay
 {

--- a/test/Microsoft.Azure.Relay.UnitTests/ConnectionStringBuilderTests.cs
+++ b/test/Microsoft.Azure.Relay.UnitTests/ConnectionStringBuilderTests.cs
@@ -1,6 +1,5 @@
-﻿//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Azure.Relay.UnitTests
 {

--- a/test/Microsoft.Azure.Relay.UnitTests/HybridConnectionTestBase.cs
+++ b/test/Microsoft.Azure.Relay.UnitTests/HybridConnectionTestBase.cs
@@ -1,6 +1,5 @@
-﻿//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Azure.Relay.UnitTests
 {

--- a/test/Microsoft.Azure.Relay.UnitTests/Logger.cs
+++ b/test/Microsoft.Azure.Relay.UnitTests/Logger.cs
@@ -1,6 +1,5 @@
-﻿//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Azure.Relay.UnitTests
 {

--- a/test/Microsoft.Azure.Relay.UnitTests/ParameterValidationTests.cs
+++ b/test/Microsoft.Azure.Relay.UnitTests/ParameterValidationTests.cs
@@ -1,6 +1,5 @@
-﻿//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Azure.Relay.UnitTests
 {

--- a/test/Microsoft.Azure.Relay.UnitTests/RunTimeTests.cs
+++ b/test/Microsoft.Azure.Relay.UnitTests/RunTimeTests.cs
@@ -1,6 +1,5 @@
-//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Azure.Relay.UnitTests
 {

--- a/test/Microsoft.Azure.Relay.UnitTests/SasKeyGenerator.cs
+++ b/test/Microsoft.Azure.Relay.UnitTests/SasKeyGenerator.cs
@@ -1,6 +1,5 @@
-﻿//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Azure.Relay.UnitTests
 {


### PR DESCRIPTION
Update source file headers to mention MIT license and refer to the LICENSE file at the project root.  (This is the file header used in the Microsoft.Azure.Amqp library sources.)