### PR TITLE
Winhttp Winsocket support for client side

### DIFF
--- a/src/Microsoft.Azure.Relay/HybridConnectionListener.cs
+++ b/src/Microsoft.Azure.Relay/HybridConnectionListener.cs
@@ -902,6 +902,7 @@ namespace Microsoft.Azure.Relay
             readonly HybridConnectionListener listener;
             readonly TokenProvider tokenProvider;
             readonly Uri rendezvousAddress;
+            readonly string subProtocol = "";
             bool complete;
             bool disposed;
 
@@ -913,6 +914,7 @@ namespace Microsoft.Azure.Relay
                 this.tokenProvider = listener.TokenProvider;
                 this.Id = acceptCommand.Id;
                 this.rendezvousAddress = new Uri(acceptCommand.Address);
+                acceptCommand.ConnectHeaders.TryGetValue(HybridConnectionConstants.Headers.SecWebSocketProtocol, out this.subProtocol);
                 this.TrackingContext = trackingContext;
             }
 
@@ -994,6 +996,7 @@ namespace Microsoft.Azure.Relay
                     clientWebSocket.Options.SetBuffer(this.bufferSize, this.bufferSize);
                     clientWebSocket.Options.SetRequestHeader("Host", this.Address.Host);
                     clientWebSocket.Options.Proxy = this.listener.Proxy;
+                    clientWebSocket.Options.AddSubProtocol(this.subProtocol);
                     clientWebSocket.Options.KeepAliveInterval = HybridConnectionConstants.KeepAliveInterval;
 
                     using (var cancelSource = new CancellationTokenSource(timeoutHelper.RemainingTime()))

--- a/src/Microsoft.Azure.Relay/HybridConnectionListener.cs
+++ b/src/Microsoft.Azure.Relay/HybridConnectionListener.cs
@@ -902,7 +902,7 @@ namespace Microsoft.Azure.Relay
             readonly HybridConnectionListener listener;
             readonly TokenProvider tokenProvider;
             readonly Uri rendezvousAddress;
-            readonly string subProtocol = "";
+            readonly string subProtocol;
             bool complete;
             bool disposed;
 
@@ -996,7 +996,10 @@ namespace Microsoft.Azure.Relay
                     clientWebSocket.Options.SetBuffer(this.bufferSize, this.bufferSize);
                     clientWebSocket.Options.SetRequestHeader("Host", this.Address.Host);
                     clientWebSocket.Options.Proxy = this.listener.Proxy;
-                    clientWebSocket.Options.AddSubProtocol(this.subProtocol);
+                    if (!string.IsNullOrEmpty(this.subProtocol)) 
+                    {
+                        clientWebSocket.Options.AddSubProtocol(this.subProtocol);
+                    }
                     clientWebSocket.Options.KeepAliveInterval = HybridConnectionConstants.KeepAliveInterval;
 
                     using (var cancelSource = new CancellationTokenSource(timeoutHelper.RemainingTime()))


### PR DESCRIPTION
Winhttp Winsocket requires subprotocol in header.  Copy subprotocol on listener side when accepting new connection.  This is a quick fix, ideally all headers that apply are returned, or listener can select sub protocol based on application.  If you fix it correctly in 1.3, please disregard this pull request.