### PR TITLE
Fix an issue with project file conversion

### DIFF
--- a/test/Microsoft.Azure.Relay.UnitTests/Microsoft.Azure.Relay.UnitTests.csproj
+++ b/test/Microsoft.Azure.Relay.UnitTests/Microsoft.Azure.Relay.UnitTests.csproj
@@ -23,12 +23,19 @@
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
-    <PackageReference Include="System.Net.WebSockets.Client" Version="4.0.0" />
   </ItemGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net46' ">
+    <DefineConstants>$(DefineConstants);NET46</DefineConstants>
+  </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
+    <PackageReference Include="System.Net.WebSockets.Client" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.Azure.Relay.UnitTests/RunTimeTests.cs
+++ b/test/Microsoft.Azure.Relay.UnitTests/RunTimeTests.cs
@@ -344,15 +344,13 @@ namespace Microsoft.Azure.Relay.UnitTests
 
                 listener = new HybridConnectionListener(fakeEndpointConnectionString);
                 var client = new HybridConnectionClient(fakeEndpointConnectionString);
-#if NET451
+#if NET46
                 await Assert.ThrowsAsync<EndpointNotFoundException>(() => listener.OpenAsync());
                 await Assert.ThrowsAsync<EndpointNotFoundException>(() => client.CreateConnectionAsync());
 #else
                 await Assert.ThrowsAsync<RelayException>(() => listener.OpenAsync());
                 await Assert.ThrowsAsync<RelayException>(() => client.CreateConnectionAsync());
 #endif
-
-
             }
             finally
             {


### PR DESCRIPTION
As part of the update from project.json to *.csproj this update was missed. Caused a test failure on .NET Framework (but not .NET Core).