### PR TITLE
Use HttpUtility in .net framework, QueryHelpers in .net core

### DIFF
--- a/src/Microsoft.Azure.Relay/HybridConnectionUtility.cs
+++ b/src/Microsoft.Azure.Relay/HybridConnectionUtility.cs
@@ -4,13 +4,17 @@
 namespace Microsoft.Azure.Relay
 {
     using System;
+    using System.Collections.Generic;
     using System.Collections.Specialized;
-    using System.IO;
     using System.Net;
-    using System.Net.WebSockets;
     using System.Text;
-    using System.Threading;
-    using System.Threading.Tasks;
+#if NET45
+    using System.Web;
+#else
+    // NETSTANDARD
+    using Microsoft.AspNetCore.WebUtilities;
+    using Microsoft.Extensions.Primitives;
+#endif
 
     static class HybridConnectionUtility
     {
@@ -49,6 +53,18 @@ namespace Microsoft.Azure.Relay
             }.Uri;
         }
 
+#if NET45
+        public static NameValueCollection ParseQueryString(string queryString)
+        {
+            return HttpUtility.ParseQueryString(queryString);
+        }
+#else
+        public static IDictionary<string, StringValues> ParseQueryString(string queryString)
+        {
+            return QueryHelpers.ParseQuery(queryString);
+        }
+#endif
+
         /// <summary>
         /// Filters out any query string values which start with the 'sb-hc-' prefix.  The returned string never
         /// has a '?' character at the start.
@@ -61,34 +77,11 @@ namespace Microsoft.Azure.Relay
             }
 
             queryString = queryString.TrimStart(QuestionMark);
-            var queryStringCollection = new NameValueCollection(StringComparer.OrdinalIgnoreCase);
-            foreach (var nameValueString in queryString.Split(Ampersand))
-            {
-                if (!string.IsNullOrEmpty(nameValueString))
-                {
-                    string[] nameAndValue = nameValueString.Split(EqualSign, 2);
-                    if (nameAndValue.Length == 2)
-                    {
-                        queryStringCollection[nameAndValue[0]] = nameAndValue[1];
-                    }
-                    else
-                    {
-                        queryStringCollection[nameAndValue[0]] = string.Empty;
-                    }
-                }
-            }
+            var queryStringCollection = ParseQueryString(queryString);
 
-            return FilterQueryString(queryStringCollection);
-        }
-
-        /// <summary>
-        /// Filters out any query string values which start with the 'sb-hc-' prefix.  The returned string never
-        /// has a '?' character at the start.
-        /// </summary>
-        public static string FilterQueryString(NameValueCollection queryString)
-        {
             var sb = new StringBuilder(256);
-            foreach (string key in queryString.Keys)
+
+            foreach (string key in queryStringCollection.Keys)
             {
                 if (key != null && key.StartsWith(HybridConnectionConstants.QueryStringKeyPrefix, StringComparison.Ordinal))
                 {
@@ -100,7 +93,7 @@ namespace Microsoft.Azure.Relay
                     sb.Append('&');
                 }
 
-                sb.Append(WebUtility.UrlEncode(key)).Append('=').Append(WebUtility.UrlEncode(queryString[key]));
+                sb.Append(WebUtility.UrlEncode(key)).Append('=').Append(WebUtility.UrlEncode(queryStringCollection[key]));
             }
 
             return sb.ToString();

--- a/src/Microsoft.Azure.Relay/HybridHttpConnection.cs
+++ b/src/Microsoft.Azure.Relay/HybridHttpConnection.cs
@@ -9,7 +9,6 @@ namespace Microsoft.Azure.Relay
     using System.Net.WebSockets;
     using System.Threading;
     using System.Threading.Tasks;
-    using Microsoft.AspNetCore.WebUtilities;
 #if CUSTOM_CLIENTWEBSOCKET
     using ClientWebSocket = Microsoft.Azure.Relay.WebSockets.ClientWebSocket;
 #endif
@@ -60,7 +59,7 @@ namespace Microsoft.Azure.Relay
 
         TrackingContext GetTrackingContext()
         {
-            var queryParameters = QueryHelpers.ParseQuery(this.rendezvousAddress.Query);
+            var queryParameters = HybridConnectionUtility.ParseQueryString(this.rendezvousAddress.Query);
             string trackingId = queryParameters[HybridConnectionConstants.Id];
             return TrackingContext.Create(trackingId, this.rendezvousAddress);
         }

--- a/src/Microsoft.Azure.Relay/Microsoft.Azure.Relay.csproj
+++ b/src/Microsoft.Azure.Relay/Microsoft.Azure.Relay.csproj
@@ -37,21 +37,20 @@
     <Reference Include="System.Xml" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Web" />
+    <Compile Remove="WebSockets\NetCore\*.cs" />
   </ItemGroup>
   
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net451' ">
     <DefineConstants>$(DefineConstants);NET45;SERIALIZATION</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
-    <Compile Remove="WebSockets\NetCore\*.cs" />
-  </ItemGroup>
-
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
     <DefineConstants>$(DefineConstants);NETSTANDARD;CUSTOM_CLIENTWEBSOCKET</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="1.0.0" />
     <PackageReference Include="System.Buffers" Version="4.3.0" />
     <PackageReference Include="System.Collections.Specialized" Version="4.0.1" />
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.0.0" />
@@ -62,10 +61,6 @@
     <PackageReference Include="System.Runtime.Serialization.Json" Version="4.0.2" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.1.1" />
     <PackageReference Include="System.Runtime.Serialization.Xml" Version="4.1.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="1.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Description
Don't require Microsoft.AspNetCore.WebUtilities and its dependecies in full .NET Framework.

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [ ] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [ ] If applicable, the public code is properly documented.
- [ ] Pull request includes test coverage for the included changes.
- [ ] The code builds without any errors.