### PR TITLE
Flow the RemoteEndpoint to the HybridConnectionListener

### DIFF
--- a/src/Microsoft.Azure.Relay/HybridConnectionListener.cs
+++ b/src/Microsoft.Azure.Relay/HybridConnectionListener.cs
@@ -428,6 +428,7 @@ namespace Microsoft.Azure.Relay
 
             var listenerContext = new RelayedHttpListenerContext(
                 this, requestUri, acceptCommand.Id, "GET", acceptCommand.ConnectHeaders);
+            listenerContext.Request.SetRemoteAddress(acceptCommand.RemoteEndpoint);
 
             RelayEventSource.Log.RelayListenerRendezvousStart(listenerContext.Listener, listenerContext.TrackingContext.TrackingId, acceptCommand.Address);
             try

--- a/src/Microsoft.Azure.Relay/HybridHttpConnection.cs
+++ b/src/Microsoft.Azure.Relay/HybridHttpConnection.cs
@@ -160,6 +160,7 @@ namespace Microsoft.Azure.Relay
                 requestCommand.Id,
                 requestCommand.Method,
                 requestCommand.RequestHeaders);
+            listenerContext.Request.SetRemoteAddress(requestCommand.RemoteEndpoint);
             listenerContext.Response.StatusCode = HttpStatusCode.OK;
             listenerContext.Response.OutputStream = new ResponseStream(this, listenerContext);
 

--- a/src/Microsoft.Azure.Relay/ListenerCommand.cs
+++ b/src/Microsoft.Azure.Relay/ListenerCommand.cs
@@ -107,6 +107,9 @@ namespace Microsoft.Azure.Relay
             [DataMember(Name = "connectHeaders", Order = 2)]
             IDictionary<string, string> connectHeaders;
 
+            [DataMember(Name = "remoteEndpoint", Order = 3, EmitDefaultValue = false, IsRequired = false)]
+            Endpoint remoteEndpoint { get; set; }
+
             [IgnoreDataMember]
             public IDictionary<string, string> ConnectHeaders
             {
@@ -118,6 +121,20 @@ namespace Microsoft.Azure.Relay
                     }
 
                     return this.connectHeaders;
+                }
+            }
+
+            [IgnoreDataMember]
+            public Endpoint RemoteEndpoint
+            {
+                get
+                {
+                    if (this.remoteEndpoint == null)
+                    {
+                        this.remoteEndpoint = new Endpoint();
+                    }
+
+                    return this.remoteEndpoint;
                 }
             }
         }
@@ -142,12 +159,16 @@ namespace Microsoft.Azure.Relay
         /// <para/>
         /// {
         ///   "request" : {
-        ///     "address" : "wss://dc-node.servicebus.windows.net:443/$hc/{path}?...",
-        ///     "id" : "42c34cb5-7a04-4d40-a19f-bdc66441e736",
+        ///     "address" : "wss://dc-node.servicebus.windows.net:443/$hc/{path}?sb-hc-action=request&amp;...",
+        ///     "id" : "42c34cb5-7a04-4d40-a19f-bdc66441e736_G10",
         ///     "requestTarget" : "/abc/def?myarg=value&amp;otherarg=...",
-        ///     "method" : "GET",    
+        ///     "method" : "GET",
+        ///     "remoteEndpoint" : {
+        ///       "address" : "10.0.0.1",
+        ///       "port" : 1234,
+        ///     },
         ///     "requestHeaders" : {
-        ///       "Host": "contoso.servicebus.windows.net:443"
+        ///       "Host": "contoso.servicebus.windows.net"
         ///       "Content-Type" : "...",
         ///       "User-Agent" : "...",
         ///     },
@@ -170,11 +191,28 @@ namespace Microsoft.Azure.Relay
             [DataMember(Name = "method", Order = 3, EmitDefaultValue = false, IsRequired = false)]
             public string Method { get; set; }
 
-            [DataMember(Name = "requestHeaders", Order = 4, EmitDefaultValue = false, IsRequired = false)]
+            [DataMember(Name = "remoteEndpoint", Order = 4, EmitDefaultValue = false, IsRequired = false)]
+            Endpoint remoteEndpoint { get; set; }
+
+            [DataMember(Name = "requestHeaders", Order = 5, EmitDefaultValue = false, IsRequired = false)]
             IDictionary<string, string> requestHeaders;
 
-            [DataMember(Name = "body", Order = 5, EmitDefaultValue = false, IsRequired = false)]
+            [DataMember(Name = "body", Order = 6, EmitDefaultValue = false, IsRequired = false)]
             public bool? Body { get; set; }
+
+            [IgnoreDataMember]
+            public Endpoint RemoteEndpoint
+            {
+                get
+                {
+                    if (this.remoteEndpoint == null)
+                    {
+                        this.remoteEndpoint = new Endpoint();
+                    }
+
+                    return this.remoteEndpoint;
+                }
+            }
 
             [IgnoreDataMember]
             public IDictionary<string, string> RequestHeaders
@@ -237,6 +275,26 @@ namespace Microsoft.Azure.Relay
                     return this.responseHeaders;
                 }
             }
+        }
+
+        /// <summary>
+        /// DataContract for JSON such as the following:
+        /// <para/>
+        /// {
+        ///   "endpoint" : {
+        ///     "address" : "10.0.0.1",
+        ///     "port" : 1234
+        ///   }
+        /// }
+        /// </summary>
+        [DataContract]
+        public class Endpoint
+        {
+            [DataMember(Name = "address", EmitDefaultValue = false, IsRequired = false)]
+            public string Address { get; set; }
+
+            [DataMember(Name = "port", EmitDefaultValue = false, IsRequired = false)]
+            public int Port { get; set; }
         }
 
 #if DEBUG

--- a/src/Microsoft.Azure.Relay/RelayedHttpListenerRequest.cs
+++ b/src/Microsoft.Azure.Relay/RelayedHttpListenerRequest.cs
@@ -43,9 +43,32 @@ namespace Microsoft.Azure.Relay
             get; internal set;
         }
 
+        /// <summary>Gets the client IP address and port number from which the request originated.</summary>
+        public IPEndPoint RemoteEndPoint
+        {
+            get; private set;
+        }
+
         /// <summary>
         /// Gets the Uri requested by the client.
         /// </summary>
         public Uri Url { get; }
+
+        internal void SetRemoteAddress(ListenerCommand.Endpoint remoteEndpoint)
+        {
+            string remoteAddress = remoteEndpoint?.Address;
+            if (!string.IsNullOrEmpty(remoteAddress))
+            {
+                IPAddress ipAddress;
+                if (IPAddress.TryParse(remoteAddress, out ipAddress))
+                {
+                    this.RemoteEndPoint = new IPEndPoint(ipAddress, remoteEndpoint.Port);
+                }
+                else
+                {
+                    RelayEventSource.Log.Warning(this, "Unable to parse 'remoteEndpoint.address'.");
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Description
Add ListenerContext.Request.RemoteEndpoint property so that users of HybridConnectionListener can access the details of the remote endpoint which is connected to the relay cloud service. I ran the unit tests locally since CI is still broken.

This checklist is used to make sure that common guidelines for a pull request are followed.
- [x] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [x] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [x] If applicable, the public code is properly documented.
- [x] Pull request includes test coverage for the included changes.
- [x] The code builds without any errors.