### PR TITLE
Allow selecting the ClientWebSocket implementation

### DIFF
--- a/src/Microsoft.Azure.Relay/ClientWebSocketFactory.cs
+++ b/src/Microsoft.Azure.Relay/ClientWebSocketFactory.cs
@@ -1,0 +1,105 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.Relay
+{
+    using System;
+    using System.Net;
+    using System.Net.WebSockets;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    interface IClientWebSocket
+    {
+        IClientWebSocketOptions Options { get; }
+
+        WebSocket WebSocket { get; }
+
+        Task ConnectAsync(Uri uri, CancellationToken cancellationToken);
+    }
+
+    interface IClientWebSocketOptions
+    {
+        IWebProxy Proxy { get; set; }
+
+        TimeSpan KeepAliveInterval { get; set; }
+
+        void AddSubProtocol(string subProtocol);
+
+        void SetBuffer(int receiveBufferSize, int sendBufferSize);
+
+        void SetRequestHeader(string name, string value);
+    }
+
+    abstract class ClientWebSocketFactory
+    {
+        public abstract WebSocket WebSocket { get; }
+
+        public static IClientWebSocket Create(bool useBuiltInWebSocket)
+        {
+#if NETSTANDARD
+            if (!useBuiltInWebSocket)
+            {
+                return new Microsoft.Azure.Relay.WebSockets.ClientWebSocket();
+            }
+#endif // NETSTANDARD
+
+            return new FrameworkClientWebSocketProxy(new System.Net.WebSockets.ClientWebSocket());
+        }
+
+        class FrameworkClientWebSocketProxy : IClientWebSocket
+        {
+            readonly System.Net.WebSockets.ClientWebSocket client;
+
+            public FrameworkClientWebSocketProxy(System.Net.WebSockets.ClientWebSocket client)
+            {
+                this.client = client;
+                this.Options = new FrameworkClientWebSocketOptions(this.client.Options);
+            }
+
+            public IClientWebSocketOptions Options { get; }
+            
+            public WebSocket WebSocket { get => this.client; }
+
+            public Task ConnectAsync(Uri uri, CancellationToken cancellationToken)
+            {
+                return this.client.ConnectAsync(uri, cancellationToken);
+            }
+
+            class FrameworkClientWebSocketOptions : IClientWebSocketOptions
+            {
+                readonly System.Net.WebSockets.ClientWebSocketOptions options;
+                public FrameworkClientWebSocketOptions(System.Net.WebSockets.ClientWebSocketOptions options)
+                {
+                    this.options = options;
+                }
+                public IWebProxy Proxy
+                {
+                    get => this.options.Proxy;
+                    set => this.options.Proxy = value;
+                }
+
+                public TimeSpan KeepAliveInterval
+                {
+                    get => this.options.KeepAliveInterval;
+                    set => this.options.KeepAliveInterval = value;
+                }
+
+                public void AddSubProtocol(string subProtocol)
+                {
+                    this.options.AddSubProtocol(subProtocol);
+                }
+               
+                public void SetBuffer(int receiveBufferSize, int sendBufferSize)
+                {
+                    this.options.SetBuffer(receiveBufferSize, sendBufferSize);
+                }
+
+                public void SetRequestHeader(string name, string value)
+                {
+                    this.options.SetRequestHeader(name, value);
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.Azure.Relay/ClientWebSocketFactory.cs
+++ b/src/Microsoft.Azure.Relay/ClientWebSocketFactory.cs
@@ -31,10 +31,8 @@ namespace Microsoft.Azure.Relay
         void SetRequestHeader(string name, string value);
     }
 
-    abstract class ClientWebSocketFactory
+    static class ClientWebSocketFactory
     {
-        public abstract WebSocket WebSocket { get; }
-
         public static IClientWebSocket Create(bool useBuiltInWebSocket)
         {
 #if NETSTANDARD

--- a/src/Microsoft.Azure.Relay/HybridConnectionConstants.cs
+++ b/src/Microsoft.Azure.Relay/HybridConnectionConstants.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Azure.Relay
         public const string HybridConnectionRequestUri = "/$hc";
         public const string SecureWebSocketScheme = "wss";
         public const int MaxUnrecognizedJson = 1024;
+        public static readonly bool DefaultUseBuiltInClientWebSocket = false;
 
         // Names of query string options
         public const string QueryStringKeyPrefix = "sb-hc-";

--- a/src/Microsoft.Azure.Relay/Microsoft.Azure.Relay.csproj
+++ b/src/Microsoft.Azure.Relay/Microsoft.Azure.Relay.csproj
@@ -43,7 +43,7 @@
   
   <!-- .NET Standard 2.0 -->
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <DefineConstants>$(DefineConstants);NETSTANDARD;CUSTOM_CLIENTWEBSOCKET</DefineConstants>
+    <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
   </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="1.0.0" />

--- a/src/Microsoft.Azure.Relay/WebSockets/NetCore/ClientWebSocket.cs
+++ b/src/Microsoft.Azure.Relay/WebSockets/NetCore/ClientWebSocket.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Azure.Relay.WebSockets
     using System.Threading.Tasks;
 
     // From: https://github.com/dotnet/corefx/blob/master/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/ClientWebSocket.cs
-    sealed partial class ClientWebSocket : WebSocket
+    sealed partial class ClientWebSocket : WebSocket, IClientWebSocket
     {
         private enum InternalState
         {
@@ -29,13 +29,13 @@ namespace Microsoft.Azure.Relay.WebSockets
 
         public ClientWebSocket()
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.IsEnabled) { NetEventSource.Enter(this); }
             WebSocketHandle.CheckPlatformSupport();
 
             _state = (int)InternalState.Created;
             _options = new ClientWebSocketOptions();
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.IsEnabled) { NetEventSource.Exit(this); }
         }
 
         #region Properties
@@ -47,6 +47,10 @@ namespace Microsoft.Azure.Relay.WebSockets
                 return _options;
             }
         }
+
+        IClientWebSocketOptions IClientWebSocket.Options => _options;
+
+        WebSocket IClientWebSocket.WebSocket => this;
 
         public override WebSocketCloseStatus? CloseStatus
         {
@@ -155,7 +159,7 @@ namespace Microsoft.Azure.Relay.WebSockets
             }
             catch (Exception ex)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Error(this, ex);
+                if (NetEventSource.IsEnabled) { NetEventSource.Error(this, ex); }
                 throw;
             }
         }

--- a/src/Microsoft.Azure.Relay/WebSockets/NetCore/ClientWebSocketOptions.cs
+++ b/src/Microsoft.Azure.Relay/WebSockets/NetCore/ClientWebSocketOptions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Azure.Relay.WebSockets
     using System.Threading;
 
     // From: https://github.com/dotnet/corefx/blob/master/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/ClientWebSocketOptions.cs
-    sealed class ClientWebSocketOptions
+    sealed class ClientWebSocketOptions : IClientWebSocketOptions
     {
         private bool _isReadOnly; // After ConnectAsync is called the options cannot be modified.
         private readonly List<string> _requestedSubProtocols;


### PR DESCRIPTION
## Description
Adding UseBuiltInClientWebSocket property to HybridConnectionClient and HybridConnectionListener to control which ClientWebSocket implementation is used.

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [X] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [X] If applicable, the public code is properly documented.
- [X] Pull request includes test coverage for the included changes.
- [X] The code builds without any errors.