### PR TITLE
Fix a race condition between HTTPS response and listener close

### DIFF
--- a/src/Microsoft.Azure.Relay/Strings.Designer.cs
+++ b/src/Microsoft.Azure.Relay/Strings.Designer.cs
@@ -187,15 +187,6 @@ namespace Microsoft.Azure.Relay {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This &apos;{0}&apos; instance has already been started once. To start another instance, please create a new &apos;{0}&apos; object and start that..
-        /// </summary>
-        internal static string InstanceAlreadyRunning {
-            get {
-                return ResourceManager.GetString("InstanceAlreadyRunning", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to The Uri address given contains a path which is not allowed. Remove the path from the supplied Uri &apos;{0}&apos;..
         /// </summary>
         internal static string InvalidAddressPath {

--- a/src/Microsoft.Azure.Relay/Strings.resx
+++ b/src/Microsoft.Azure.Relay/Strings.resx
@@ -126,9 +126,6 @@
   <data name="EntityClosedOrAborted" xml:space="preserve">
     <value>The operation cannot be performed because the entity has been closed or aborted.</value>
   </data>
-  <data name="InstanceAlreadyRunning" xml:space="preserve">
-    <value>This '{0}' instance has already been started once. To start another instance, please create a new '{0}' object and start that.</value>
-  </data>
   <data name="InvalidAsyncResult" xml:space="preserve">
     <value>The specified Async result object is null or invalid.</value>
   </data>


### PR DESCRIPTION
## Description
When HybridConnectionListener.CloseAsync calls WebSocket.CloseOutputAsync this is also a "Send" operation as far as the websocket is concerned. In order to avoid `InvalidOperationException: There is already one outstanding 'SendAsync' call for this WebSocket instance` make sure that CloseOutputAsync also uses the sendAsyncLock.

- [X] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [X] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [N/A] If applicable, the public code is properly documented.
- [X] Pull request includes test coverage for the included changes.
- [X] The code builds without any errors.