### PR TITLE
HybridConnectionClient Request Headers feature

### DIFF
--- a/test/Microsoft.Azure.Relay.UnitTests/RunTimeTests.cs
+++ b/test/Microsoft.Azure.Relay.UnitTests/RunTimeTests.cs
@@ -224,6 +224,29 @@ namespace Microsoft.Azure.Relay.UnitTests
             }
         }
 
+        [Fact, DisplayTestMethodName]
+        async Task RequestHeadersNegativeTest()
+        {
+            async Task CheckBadHeaderAsync(HybridConnectionClient client, string headerName, string headerValue)
+            {
+                TestUtility.Log($"CheckBadHeader: \"{headerName}\": \"{headerValue}\"");
+                await Assert.ThrowsAnyAsync<ArgumentException>(() =>
+                {
+                    var clientRequestHeaders = new Dictionary<string, string>();
+                    clientRequestHeaders[headerName] = headerValue;
+                    return client.CreateConnectionAsync(clientRequestHeaders);
+                });
+            }
+
+            var hybridConnectionClient = GetHybridConnectionClient(EndpointTestType.Unauthenticated);
+            await CheckBadHeaderAsync(hybridConnectionClient, string.Empty, string.Empty);
+            await CheckBadHeaderAsync(hybridConnectionClient, null, null);
+            await CheckBadHeaderAsync(hybridConnectionClient, "Bad\nHeader", "Value");
+            await CheckBadHeaderAsync(hybridConnectionClient, "Bad:Header", "Value");
+            await CheckBadHeaderAsync(hybridConnectionClient, "Header", "Bad\rValue");
+            await CheckBadHeaderAsync(hybridConnectionClient, "Header", "Bad\nValue");
+        }
+
         [Theory, DisplayTestMethodName]
         [MemberData(nameof(AuthenticationTestPermutations))]
         async Task WriteLargeDataSetTest(EndpointTestType endpointTestType, int kilobytesToSend = 1024)


### PR DESCRIPTION
## Description
Allow HybridConnectionClient to specify Custom HTTP Request Headers when connecting.

- [X] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [X] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [X] If applicable, the public code is properly documented.
- [X] Pull request includes test coverage for the included changes.
![image](https://user-images.githubusercontent.com/11354387/54459355-b190e000-4723-11e9-9172-bcbd85be6c3a.png)
- [X] The code builds without any errors.