### PR TITLE
Throw if listener tries to change headers after writing to the output stream

### DIFF
--- a/src/Microsoft.Azure.Relay/HybridHttpConnection.cs
+++ b/src/Microsoft.Azure.Relay/HybridHttpConnection.cs
@@ -411,6 +411,7 @@ namespace Microsoft.Azure.Relay
             public override async Task WriteAsync(byte[] array, int offset, int count, CancellationToken cancelToken)
             {
                 RelayEventSource.Log.HybridHttpResponseStreamWrite(this.TrackingContext, count);
+                this.context.Response.SetReadOnly();
                 using (var timeoutCancelSource = new CancellationTokenSource(this.WriteTimeout))
                 using (var linkedCancelSource = CancellationTokenSource.CreateLinkedTokenSource(cancelToken, timeoutCancelSource.Token))
                 using (await this.asyncLock.LockAsync(linkedCancelSource.Token).ConfigureAwait(false))

--- a/src/Microsoft.Azure.Relay/RelayedHttpListenerResponse.cs
+++ b/src/Microsoft.Azure.Relay/RelayedHttpListenerResponse.cs
@@ -188,6 +188,12 @@ namespace Microsoft.Azure.Relay
                 this.response.CheckDisposedOrReadOnly();
                 base.Add(name, value);
             }
+            
+            public override void Clear()
+            {
+                this.response.CheckDisposedOrReadOnly();
+                base.Clear();
+            }
 
             public override void Remove(string name)
             {

--- a/src/Microsoft.Azure.Relay/Strings.Designer.cs
+++ b/src/Microsoft.Azure.Relay/Strings.Designer.cs
@@ -592,6 +592,15 @@ namespace Microsoft.Azure.Relay {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The HTTP status code, status description, and headers cannot be modified after writing to the output stream..
+        /// </summary>
+        internal static string ResponseBodyStarted {
+            get {
+                return ResourceManager.GetString("ResponseBodyStarted", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {0} cannot be specified along with {1}. {0} alone should be sufficient to Authenticate the request..
         /// </summary>
         internal static string SasTokenShouldBeAlone {

--- a/src/Microsoft.Azure.Relay/Strings.resx
+++ b/src/Microsoft.Azure.Relay/Strings.resx
@@ -312,4 +312,7 @@
   <data name="net_WebSockets_proxyauthentication" xml:space="preserve">
     <value>Connecting to proxy requires credentials.</value>
   </data>
+  <data name="ResponseBodyStarted" xml:space="preserve">
+    <value>The HTTP status code, status description, and headers cannot be modified after writing to the output stream.</value>
+  </data>
 </root>

--- a/test/Microsoft.Azure.Relay.UnitTests/HybridRequestTests.cs
+++ b/test/Microsoft.Azure.Relay.UnitTests/HybridRequestTests.cs
@@ -580,6 +580,74 @@ namespace Microsoft.Azure.Relay.UnitTests
             }
         }
 
+        [Theory, DisplayTestMethodName]
+        [MemberData(nameof(AuthenticationTestPermutations))]
+        async Task ResponseHeadersAfterBody(EndpointTestType endpointTestType)
+        {
+            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+            var listener = this.GetHybridConnectionListener(endpointTestType);
+            try
+            {
+                await listener.OpenAsync(cts.Token);
+
+                var requestHandlerComplete = new TaskCompletionSource<object>();
+                listener.RequestHandler = (context) =>
+                {
+                    TestUtility.Log($"RequestHandler: {context.Request.HttpMethod} {context.Request.Url}");
+                    try
+                    {
+                        // Begin writing to the output stream
+                        context.Response.OutputStream.WriteByte((byte)'X');
+
+                        // Now try to change some things which are no longer mutable
+                        var exception = Assert.Throws<InvalidOperationException>(() => context.Response.StatusCode = HttpStatusCode.Found);
+                        Assert.Contains("TrackingId", exception.Message, StringComparison.OrdinalIgnoreCase);
+                        exception = Assert.Throws<InvalidOperationException>(() => context.Response.StatusDescription = "Test Description");
+                        Assert.Contains("TrackingId", exception.Message, StringComparison.OrdinalIgnoreCase);
+                        exception = Assert.Throws<InvalidOperationException>(() => context.Response.Headers["CustomHeader"] = "Header value");
+                        Assert.Contains("TrackingId", exception.Message, StringComparison.OrdinalIgnoreCase);
+
+                        context.Response.OutputStream.Close();
+                        requestHandlerComplete.TrySetResult(null);
+                    }
+                    catch (Exception e)
+                    {
+                        requestHandlerComplete.TrySetException(e);
+                    }
+                };
+
+                RelayConnectionStringBuilder connectionString = GetConnectionStringBuilder(endpointTestType);
+                Uri endpointUri = connectionString.Endpoint;
+                Uri hybridHttpUri = new UriBuilder("https://", endpointUri.Host, endpointUri.Port, connectionString.EntityPath).Uri;
+
+                using (var client = new HttpClient { BaseAddress = hybridHttpUri })
+                {
+                    client.DefaultRequestHeaders.ExpectContinue = false;
+
+                    var getRequest = new HttpRequestMessage();
+                    await AddAuthorizationHeader(connectionString, getRequest, hybridHttpUri);
+                    LogRequest(getRequest, client);
+                    var sendTask = client.SendAsync(getRequest);
+
+                    // This will throw if anything failed in the RequestHandler
+                    await requestHandlerComplete.Task;
+
+                    using (HttpResponseMessage response = await sendTask)
+                    {
+                        LogResponse(response);
+                        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                        Assert.Equal(1, (await response.Content.ReadAsStreamAsync()).Length);
+                    }
+                }
+
+                await listener.CloseAsync(cts.Token);
+            }
+            finally
+            {
+                await SafeCloseAsync(listener);
+            }
+        }
+
         [Fact, DisplayTestMethodName]
         async Task StatusCodes()
         {


### PR DESCRIPTION
## Description
Throw InvalidOperationException if listener attempts to change status code, description, or headers after writing to the output stream.

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [X] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module). **It will throw instead of silently not doing what the user's code in the listener attempted to do.**
- [X] If applicable, the public code is properly documented.
- [X] Pull request includes test coverage for the included changes.
- [X] The code builds without any errors.