### PR TITLE
Ensure the exception contract from Relay/HC operations is correct

### DIFF
--- a/src/Microsoft.Azure.Relay/HybridConnectionClient.cs
+++ b/src/Microsoft.Azure.Relay/HybridConnectionClient.cs
@@ -204,7 +204,7 @@ namespace Microsoft.Azure.Relay
                 RelayEventSource.Log.ObjectConnected(traceSource, trackingContext);
                 return new WebSocketStream(webSocket.WebSocket, trackingContext);
             }
-            catch (Exception exception) when (!WebSocketExceptionHelper.IsRelayContract(exception) && !(exception is ArgumentException))
+            catch (Exception exception) when (!WebSocketExceptionHelper.IsRelayContract(exception))
             {
                 throw RelayEventSource.Log.ThrowingException(
                     WebSocketExceptionHelper.ConvertToRelayContract(exception, trackingContext, webSocket.Response, isListener: false),

--- a/src/Microsoft.Azure.Relay/HybridConnectionClient.cs
+++ b/src/Microsoft.Azure.Relay/HybridConnectionClient.cs
@@ -204,10 +204,10 @@ namespace Microsoft.Azure.Relay
                 RelayEventSource.Log.ObjectConnected(traceSource, trackingContext);
                 return new WebSocketStream(webSocket.WebSocket, trackingContext);
             }
-            catch (WebSocketException wsException)
+            catch (Exception exception) when (!WebSocketExceptionHelper.IsRelayContract(exception) && !(exception is ArgumentException))
             {
                 throw RelayEventSource.Log.ThrowingException(
-                    WebSocketExceptionHelper.ConvertToRelayContract(wsException, trackingContext, webSocket.Response, isListener: false),
+                    WebSocketExceptionHelper.ConvertToRelayContract(exception, trackingContext, webSocket.Response, isListener: false),
                     traceSource);
             }
         }

--- a/src/Microsoft.Azure.Relay/HybridConnectionListener.cs
+++ b/src/Microsoft.Azure.Relay/HybridConnectionListener.cs
@@ -715,10 +715,10 @@ namespace Microsoft.Azure.Relay
                     RelayEventSource.Log.ObjectConnected(this.listener);
                     return webSocket.WebSocket;
                 }
-                catch (WebSocketException wsException)
+                catch (Exception exception) when (!WebSocketExceptionHelper.IsRelayContract(exception))
                 {
                     throw RelayEventSource.Log.ThrowingException(
-                        WebSocketExceptionHelper.ConvertToRelayContract(wsException, this.listener.TrackingContext, webSocket.Response), this.listener);
+                        WebSocketExceptionHelper.ConvertToRelayContract(exception, this.listener.TrackingContext, webSocket.Response), this.listener);
                 }
             }
 

--- a/src/Microsoft.Azure.Relay/ManagementOperations.cs
+++ b/src/Microsoft.Azure.Relay/ManagementOperations.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Azure.Relay
                     throw await CreateExceptionForFailedResponseAsync(httpResponse).ConfigureAwait(false);
                 }
             }
-            catch (Exception exception) when (!Fx.IsFatal(exception) && !(exception is RelayException))
+            catch (Exception exception) when (!WebSocketExceptionHelper.IsRelayContract(exception))
             {
                 throw WebSocketExceptionHelper.ConvertToRelayContract(exception, null);
             }

--- a/src/Microsoft.Azure.Relay/ManagementOperations.cs
+++ b/src/Microsoft.Azure.Relay/ManagementOperations.cs
@@ -49,12 +49,12 @@ namespace Microsoft.Azure.Relay
                 }
                 else
                 {
-                    throw await CreateExceptionForFailedResponseAsync(httpResponse).ConfigureAwait(false);
+                    throw RelayEventSource.Log.ThrowingException(await CreateExceptionForFailedResponseAsync(httpResponse).ConfigureAwait(false));
                 }
             }
             catch (Exception exception) when (!WebSocketExceptionHelper.IsRelayContract(exception))
             {
-                throw WebSocketExceptionHelper.ConvertToRelayContract(exception, null);
+                throw RelayEventSource.Log.ThrowingException(WebSocketExceptionHelper.ConvertToRelayContract(exception, null));
             }
             finally
             {

--- a/src/Microsoft.Azure.Relay/WebSocketExceptionHelper.cs
+++ b/src/Microsoft.Azure.Relay/WebSocketExceptionHelper.cs
@@ -12,10 +12,17 @@ namespace Microsoft.Azure.Relay
 
     static class WebSocketExceptionHelper
     {
+        public static bool IsRelayContract(Exception exception)
+        {
+            return Fx.IsFatal(exception) ||
+                exception is RelayException || 
+                exception is TimeoutException;
+        }
+
         public static Exception ConvertToRelayContract(Exception exception, TrackingContext trackingContext, HttpResponseMessage httpResponseMessage = null, bool isListener = true)
         {
             string message = exception.Message;
-            if (exception is RelayException || exception is TimeoutException)
+            if (IsRelayContract(exception))
             {
                 return exception;
             }

--- a/src/Microsoft.Azure.Relay/WebSocketStream.cs
+++ b/src/Microsoft.Azure.Relay/WebSocketStream.cs
@@ -114,9 +114,9 @@ namespace Microsoft.Azure.Relay
                     return result.Count;
                 }
             }
-            catch (WebSocketException webSocketException)
+            catch (Exception exception) when (!WebSocketExceptionHelper.IsRelayContract(exception))
             {
-                throw RelayEventSource.Log.ThrowingException(WebSocketExceptionHelper.ConvertToRelayContract(webSocketException, this.TrackingContext), this);
+                throw RelayEventSource.Log.ThrowingException(WebSocketExceptionHelper.ConvertToRelayContract(exception, this.TrackingContext), this);
             }
         }
 
@@ -153,9 +153,9 @@ namespace Microsoft.Azure.Relay
                     await this.webSocket.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, "Shutdown", linkedCancelSource.Token).ConfigureAwait(false);
                 }
             }
-            catch (WebSocketException webSocketException)
+            catch (Exception exception) when (!WebSocketExceptionHelper.IsRelayContract(exception))
             {
-                throw RelayEventSource.Log.ThrowingException(WebSocketExceptionHelper.ConvertToRelayContract(webSocketException, this.TrackingContext), this);
+                throw RelayEventSource.Log.ThrowingException(WebSocketExceptionHelper.ConvertToRelayContract(exception, this.TrackingContext), this);
             }
         }
 
@@ -179,9 +179,9 @@ namespace Microsoft.Azure.Relay
                         linkedCancelSource.Token).ConfigureAwait(false);
                 }
             }
-            catch (WebSocketException webSocketException)
+            catch (Exception exception) when (!WebSocketExceptionHelper.IsRelayContract(exception))
             {
-                throw RelayEventSource.Log.ThrowingException(WebSocketExceptionHelper.ConvertToRelayContract(webSocketException, this.TrackingContext), this);
+                throw RelayEventSource.Log.ThrowingException(WebSocketExceptionHelper.ConvertToRelayContract(exception, this.TrackingContext), this);
             }
         }
 

--- a/test/Microsoft.Azure.Relay.UnitTests/RunTimeTests.cs
+++ b/test/Microsoft.Azure.Relay.UnitTests/RunTimeTests.cs
@@ -227,11 +227,10 @@ namespace Microsoft.Azure.Relay.UnitTests
         [Fact, DisplayTestMethodName]
         async Task RequestHeadersNegativeTest()
         {
-            async Task CheckBadHeaderAsync<TException>(HybridConnectionClient client, string headerName, string headerValue)
-                where TException : Exception
+            async Task CheckBadHeaderAsync(HybridConnectionClient client, string headerName, string headerValue)
             {
                 TestUtility.Log($"CheckBadHeader: \"{headerName}\": \"{headerValue}\"");
-                await Assert.ThrowsAnyAsync<TException>(() =>
+                await Assert.ThrowsAnyAsync<RelayException>(() =>
                 {
                     var clientRequestHeaders = new Dictionary<string, string>();
                     clientRequestHeaders[headerName] = headerValue;
@@ -240,12 +239,12 @@ namespace Microsoft.Azure.Relay.UnitTests
             }
 
             var hybridConnectionClient = GetHybridConnectionClient(EndpointTestType.Unauthenticated);
-            await CheckBadHeaderAsync<RelayException>(hybridConnectionClient, string.Empty, string.Empty);
-            await CheckBadHeaderAsync<ArgumentNullException>(hybridConnectionClient, null, null);
-            await CheckBadHeaderAsync<RelayException>(hybridConnectionClient, "Bad\nHeader", "Value");
-            await CheckBadHeaderAsync<RelayException>(hybridConnectionClient, "Bad:Header", "Value");
-            await CheckBadHeaderAsync<RelayException>(hybridConnectionClient, "Header", "Bad\rValue");
-            await CheckBadHeaderAsync<RelayException>(hybridConnectionClient, "Header", "Bad\nValue");
+            await CheckBadHeaderAsync(hybridConnectionClient, string.Empty, string.Empty);
+            await CheckBadHeaderAsync(hybridConnectionClient, string.Empty, null);
+            await CheckBadHeaderAsync(hybridConnectionClient, "Bad\nHeader", "Value");
+            await CheckBadHeaderAsync(hybridConnectionClient, "Bad:Header", "Value");
+            await CheckBadHeaderAsync(hybridConnectionClient, "Header", "Bad\rValue");
+            await CheckBadHeaderAsync(hybridConnectionClient, "Header", "Bad\nValue");
         }
 
         [Theory, DisplayTestMethodName]

--- a/test/Microsoft.Azure.Relay.UnitTests/RunTimeTests.cs
+++ b/test/Microsoft.Azure.Relay.UnitTests/RunTimeTests.cs
@@ -227,10 +227,11 @@ namespace Microsoft.Azure.Relay.UnitTests
         [Fact, DisplayTestMethodName]
         async Task RequestHeadersNegativeTest()
         {
-            async Task CheckBadHeaderAsync(HybridConnectionClient client, string headerName, string headerValue)
+            async Task CheckBadHeaderAsync<TException>(HybridConnectionClient client, string headerName, string headerValue)
+                where TException : Exception
             {
                 TestUtility.Log($"CheckBadHeader: \"{headerName}\": \"{headerValue}\"");
-                await Assert.ThrowsAnyAsync<ArgumentException>(() =>
+                await Assert.ThrowsAnyAsync<TException>(() =>
                 {
                     var clientRequestHeaders = new Dictionary<string, string>();
                     clientRequestHeaders[headerName] = headerValue;
@@ -239,12 +240,12 @@ namespace Microsoft.Azure.Relay.UnitTests
             }
 
             var hybridConnectionClient = GetHybridConnectionClient(EndpointTestType.Unauthenticated);
-            await CheckBadHeaderAsync(hybridConnectionClient, string.Empty, string.Empty);
-            await CheckBadHeaderAsync(hybridConnectionClient, null, null);
-            await CheckBadHeaderAsync(hybridConnectionClient, "Bad\nHeader", "Value");
-            await CheckBadHeaderAsync(hybridConnectionClient, "Bad:Header", "Value");
-            await CheckBadHeaderAsync(hybridConnectionClient, "Header", "Bad\rValue");
-            await CheckBadHeaderAsync(hybridConnectionClient, "Header", "Bad\nValue");
+            await CheckBadHeaderAsync<RelayException>(hybridConnectionClient, string.Empty, string.Empty);
+            await CheckBadHeaderAsync<ArgumentNullException>(hybridConnectionClient, null, null);
+            await CheckBadHeaderAsync<RelayException>(hybridConnectionClient, "Bad\nHeader", "Value");
+            await CheckBadHeaderAsync<RelayException>(hybridConnectionClient, "Bad:Header", "Value");
+            await CheckBadHeaderAsync<RelayException>(hybridConnectionClient, "Header", "Bad\rValue");
+            await CheckBadHeaderAsync<RelayException>(hybridConnectionClient, "Header", "Bad\nValue");
         }
 
         [Theory, DisplayTestMethodName]


### PR DESCRIPTION
## Description
Ensure the exception contract from Relay/HC operations is always RelayException or TimeoutException.

On .NET Core using the built in ClientWebSocket implementation it can throw exceptions of type WinHttpException. HC API operations should throw RelayExceptions (including subclasses), TimeoutExceptions, or occasionally ArgumentException where the argument is invalid (e.g. Trying to send invalid HTTP headers).

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [X] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [X] If applicable, the public code is properly documented.
- [X] The code builds without any errors.