### PR TITLE
Allow using the system default web proxy on netcoreapp2.1

### DIFF
--- a/src/Microsoft.Azure.Relay/ClientWebSocketFactory.cs
+++ b/src/Microsoft.Azure.Relay/ClientWebSocketFactory.cs
@@ -45,14 +45,14 @@ namespace Microsoft.Azure.Relay
             }
 #endif // NETSTANDARD
 
-            return new FrameworkClientWebSocketProxy(new System.Net.WebSockets.ClientWebSocket());
+            return new FrameworkClientWebSocket(new System.Net.WebSockets.ClientWebSocket());
         }
 
-        class FrameworkClientWebSocketProxy : IClientWebSocket
+        class FrameworkClientWebSocket : IClientWebSocket
         {
             readonly System.Net.WebSockets.ClientWebSocket client;
 
-            public FrameworkClientWebSocketProxy(System.Net.WebSockets.ClientWebSocket client)
+            public FrameworkClientWebSocket(System.Net.WebSockets.ClientWebSocket client)
             {
                 this.client = client;
                 this.Options = new FrameworkClientWebSocketOptions(this.client.Options);
@@ -76,6 +76,7 @@ namespace Microsoft.Azure.Relay
                 {
                     this.options = options;
                 }
+
                 public IWebProxy Proxy
                 {
                     get { return this.options.Proxy; }

--- a/src/Microsoft.Azure.Relay/DefaultWebProxy.cs
+++ b/src/Microsoft.Azure.Relay/DefaultWebProxy.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.Relay
+{
+    using System;
+    using System.Net;
+
+    /// <summary>Used as a sentinel to indicate that ClientWebSocket should use the system's default proxy.</summary>
+    /// <remarks>
+    /// Approach is from:
+    /// https://github.com/dotnet/corefx/blob/master/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/ClientWebSocket.cs
+    /// </remarks>
+    sealed class DefaultWebProxy : IWebProxy
+    {
+        public static IWebProxy Instance { get; } = new DefaultWebProxy();
+
+        public ICredentials Credentials { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+
+        public Uri GetProxy(Uri destination) => throw new NotSupportedException();
+
+        public bool IsBypassed(Uri host) => throw new NotSupportedException();
+
+        /// <summary>
+        /// Set the Proxy on the client web socket options if the proxy was changed from the default.
+        /// </summary>
+        internal static void ConfigureProxy(IClientWebSocketOptions options, IWebProxy proxy)
+        {
+            if (proxy != Instance)
+            {
+                options.Proxy = proxy;
+            }
+        }
+    }
+}

--- a/src/Microsoft.Azure.Relay/HybridConnectionClient.cs
+++ b/src/Microsoft.Azure.Relay/HybridConnectionClient.cs
@@ -164,8 +164,8 @@ namespace Microsoft.Azure.Relay
             RelayEventSource.Log.ObjectConnecting(traceSource, trackingContext);
             var webSocket = ClientWebSocketFactory.Create(this.UseBuiltInClientWebSocket);
             try
-            {                
-                webSocket.Options.Proxy = this.Proxy;
+            {
+                DefaultWebProxy.ConfigureProxy(webSocket.Options, this.Proxy);
                 webSocket.Options.KeepAliveInterval = HybridConnectionConstants.KeepAliveInterval;
                 webSocket.Options.SetBuffer(this.ConnectionBufferSize, this.ConnectionBufferSize);
                 webSocket.Options.SetRequestHeader(HybridConnectionConstants.Headers.RelayUserAgent, HybridConnectionConstants.ClientAgent);
@@ -277,7 +277,7 @@ namespace Microsoft.Azure.Relay
             this.TokenProvider = tokenProvider;
             this.ConnectionBufferSize = DefaultConnectionBufferSize;
             this.OperationTimeout = operationTimeout;
-            this.Proxy = WebRequest.DefaultWebProxy;
+            this.Proxy = DefaultWebProxy.Instance;
             this.UseBuiltInClientWebSocket = HybridConnectionConstants.DefaultUseBuiltInClientWebSocket;
         }
     }

--- a/src/Microsoft.Azure.Relay/HybridConnectionListener.cs
+++ b/src/Microsoft.Azure.Relay/HybridConnectionListener.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Azure.Relay
             this.TokenProvider = tokenProvider;
             this.ConnectionBufferSize = DefaultConnectionBufferSize;
             this.OperationTimeout = RelayConstants.DefaultOperationTimeout;
-            this.proxy = WebRequest.DefaultWebProxy;
+            this.proxy = DefaultWebProxy.Instance;
             this.TrackingContext = TrackingContext.Create(this.Address);
             this.connectionInputQueue = new InputQueue<HybridConnectionStream>();
             this.controlConnection = new ControlConnection(this);
@@ -116,7 +116,7 @@ namespace Microsoft.Azure.Relay
             this.TokenProvider = builder.CreateTokenProvider();
             this.ConnectionBufferSize = DefaultConnectionBufferSize;
             this.OperationTimeout = builder.OperationTimeout;
-            this.proxy = WebRequest.DefaultWebProxy;
+            this.proxy = DefaultWebProxy.Instance;
             this.TrackingContext = TrackingContext.Create(this.Address);
             this.connectionInputQueue = new InputQueue<HybridConnectionStream>();
             this.controlConnection = new ControlConnection(this);
@@ -690,7 +690,8 @@ namespace Microsoft.Azure.Relay
 
                     RelayEventSource.Log.ObjectConnecting(this.listener);
                     webSocket.Options.SetBuffer(this.bufferSize, this.bufferSize);
-                    webSocket.Options.Proxy = this.listener.Proxy;
+                    DefaultWebProxy.ConfigureProxy(webSocket.Options, this.listener.Proxy);
+
                     webSocket.Options.KeepAliveInterval = HybridConnectionConstants.KeepAliveInterval;
                     webSocket.Options.SetRequestHeader(HybridConnectionConstants.Headers.RelayUserAgent, HybridConnectionConstants.ClientAgent);
 

--- a/src/Microsoft.Azure.Relay/HybridHttpConnection.cs
+++ b/src/Microsoft.Azure.Relay/HybridHttpConnection.cs
@@ -255,7 +255,7 @@ namespace Microsoft.Azure.Relay
             {                
                 RelayEventSource.Log.HybridHttpCreatingRendezvousConnection(this.TrackingContext);
                 var clientWebSocket = ClientWebSocketFactory.Create(this.listener.UseBuiltInClientWebSocket);
-                clientWebSocket.Options.Proxy = this.listener.Proxy;
+                DefaultWebProxy.ConfigureProxy(clientWebSocket.Options, this.listener.Proxy);
                 this.rendezvousWebSocket = clientWebSocket.WebSocket;
                 await clientWebSocket.ConnectAsync(this.rendezvousAddress, cancelToken).ConfigureAwait(false);
             }

--- a/src/Microsoft.Azure.Relay/RelayedHttpListenerContext.cs
+++ b/src/Microsoft.Azure.Relay/RelayedHttpListenerContext.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Azure.Relay
         {
             var clientWebSocket = ClientWebSocketFactory.Create(this.Listener.UseBuiltInClientWebSocket);
             clientWebSocket.Options.SetBuffer(this.Listener.ConnectionBufferSize, this.Listener.ConnectionBufferSize);
-            clientWebSocket.Options.Proxy = this.Listener.Proxy;
+            DefaultWebProxy.ConfigureProxy(clientWebSocket.Options, this.Listener.Proxy);
             clientWebSocket.Options.KeepAliveInterval = HybridConnectionConstants.KeepAliveInterval;
             return clientWebSocket;
         }

--- a/test/Microsoft.Azure.Relay.UnitTests/HybridConnectionTestBase.cs
+++ b/test/Microsoft.Azure.Relay.UnitTests/HybridConnectionTestBase.cs
@@ -64,6 +64,7 @@ namespace Microsoft.Azure.Relay.UnitTests
                 {
                     EntityPath = Constants.UnauthenticatedEntityPath
                 };
+
                 return new HybridConnectionListener(connectionStringBuilder.ToString());
             }
 


### PR DESCRIPTION
## Description
Make it possible to use the system default web proxy when UseClientWebSocket = true (requires netcoreapp2.1 or higher).
Fixes issue #104 

**Previous behavior (Version 2.0):**

Platform      | UseBuildInCWS | ProxyConfig   | ProxyUsed | Correct
--------------|---------------|---------------|-----------|----------
netcoreapp2.1 | false         | SystemDefault | No        | :x: **No**
netcoreapp2.1 | false         | ExplicitNull  | No        | :heavy_check_mark: Yes
netcoreapp2.1 | false         | ExplicitlySet | Yes       | :heavy_check_mark: Yes
netcoreapp2.1 | true          | SystemDefault | No        | :x: **No**
netcoreapp2.1 | true          | ExplicitNull  | No        | :heavy_check_mark: Yes
netcoreapp2.1 | true          | ExplicitlySet | Yes       | :heavy_check_mark: Yes

**With these changes:**

Platform      | UseBuildInCWS | ProxyConfig   | ProxyUsed | Correct
--------------|---------------|---------------|-----------|----------
netcoreapp2.1 | false         | SystemDefault | No        | :x: **No**
netcoreapp2.1 | false         | ExplicitNull  | No        | :heavy_check_mark: Yes
netcoreapp2.1 | false         | ExplicitlySet | Yes       | :heavy_check_mark: Yes
netcoreapp2.1 | true          | SystemDefault | Yes       | :heavy_check_mark: **Yes** :heavy_check_mark:
netcoreapp2.1 | true          | ExplicitNull  | No        | :heavy_check_mark: Yes
netcoreapp2.1 | true          | ExplicitlySet | Yes       | :heavy_check_mark: Yes
