### PR TITLE
allow setting response StatusDescription with null

### DIFF
--- a/src/Microsoft.Azure.Relay/RelayedHttpListenerResponse.cs
+++ b/src/Microsoft.Azure.Relay/RelayedHttpListenerResponse.cs
@@ -86,7 +86,9 @@ namespace Microsoft.Azure.Relay
                 this.CheckDisposedOrReadOnly();
                 if (value == null)
                 {
-                    throw RelayEventSource.Log.ThrowingException(new ArgumentNullException(nameof(value)), this.Context);
+                    // reset the status description back to an unset state
+                    this.statusDescription = null;
+                    return;
                 }
 
                 // Need to verify the status description doesn't contain any control characters except HT.


### PR DESCRIPTION
## Description

When using Microsoft.Azure.Relay.AspNetCore and calling HttpContext.Response.Clear()
asp.net core will set the response ReasonPhrase to null and the Microsoft.Azure.Relay.AspNetCore response implementation, in turn sets the Microsoft.Azure.Relay response StatusDescription to null.

The Azure relay implementation of Response.StatusDescription does not allow setting it with null, resulting in an exception.

This change allows setting the StatusDescription back to an unset state.

resolves #147


This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [x] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [x] If applicable, the public code is properly documented.
- [x] Pull request includes test coverage for the included changes.
- [x] The code builds without any errors.
