### PR TITLE
Handle aborted state in WebSocketStream

### DIFF
--- a/src/Microsoft.Azure.Relay/WebSocketStream.cs
+++ b/src/Microsoft.Azure.Relay/WebSocketStream.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Relay
         {
             get
             {
-                return this.webSocket.State != WebSocketState.CloseReceived && this.webSocket.State != WebSocketState.Closed;
+                return this.webSocket.State != WebSocketState.CloseReceived && this.webSocket.State != WebSocketState.Closed && this.webSocket.State != WebSocketState.Aborted;
             }
         }
 
@@ -36,14 +36,14 @@ namespace Microsoft.Azure.Relay
 
         public override bool CanTimeout
         {
-            get { return this.webSocket.State != WebSocketState.Closed; }
+            get { return this.webSocket.State != WebSocketState.Closed && this.webSocket.State != WebSocketState.Aborted; }
         }
 
         public override bool CanWrite
         {
             get
             {
-                return this.webSocket.State != WebSocketState.CloseSent && this.webSocket.State != WebSocketState.Closed;
+                return this.webSocket.State != WebSocketState.CloseSent && this.webSocket.State != WebSocketState.Closed && this.webSocket.State != WebSocketState.Aborted;
             }
         }
 


### PR DESCRIPTION
## Description
- The `WebSocketStream` (and therefore the `HybridConnectionStream`) claims that they are readable and writable even if the underlying `WebSocket` is in an `Aborted` state.
- Currently it is not possible (without reflection) to determine if the `WebSocket` is in the `Aborted` state.
- An example case of this problem:
  - Underlying `WebSocket` enters an `Aborted` state for some reason.
  - Perform any action on the `HybridConnectionStream` (e.g. shutdown).
  - The `WebSocketException` will be thrown because of the `Aborted` state.

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [x] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [x] If applicable, the public code is properly documented.
- [x] Pull request includes test coverage for the included changes.
- [x] The code builds without any errors.