### PR TITLE
Updated GetNamespaceInfo.ps1 to handle VMSS scale units

### DIFF
--- a/tools/GetNamespaceInfo.ps1
+++ b/tools/GetNamespaceInfo.ps1
@@ -60,7 +60,7 @@ function Get-SBNamespaceInfo
         $PropertyBag = @{Namespace=$ns;CloudServiceDNS=$CloudServiceDNS;Deployment=$Deployment;CloudServiceVIP=$CloudServiceVIP;GatewayDnsFormat=$GatewayDnsFormat;DirectAddresses=$DirectAddresses}
     }
 
-    $details = New-Object PSObject –Property $PropertyBag
+    $details = New-Object PSObject -Property $PropertyBag
     $details
 }
 

--- a/tools/GetNamespaceInfo.ps1
+++ b/tools/GetNamespaceInfo.ps1
@@ -1,4 +1,4 @@
-﻿Param
+Param
 (
     [Parameter(Mandatory=$true, HelpMessage="The ServiceBus namespace. E.g. 'contoso.servicebus.windows.net' or 'contoso'")]
     [string]$Namespace,
@@ -26,11 +26,26 @@ function Get-SBNamespaceInfo
         {
             $Deployment = $Deployment.Substring(7)
         }
+	if ($Deployment.StartsWith("NS-"))
+        {
+            $Deployment = $Deployment.Substring(3)
+        }
 
         $DirectAddresses = @()
         $instances = 0..127
         $ParentDomain = $ns.Substring($ns.IndexOf('.') + 1)
         $GatewayDnsFormat = ("g{{0}}-{0}-sb.{1}" -f $Deployment.ToLowerInvariant(), $ParentDomain)
+        Foreach ($index in $instances)
+        {
+            $address = ($GatewayDnsFormat -f $index)
+            $result = Resolve-DnsName $address -EA SilentlyContinue
+            if ($result -ne $null)
+            {
+                $DirectAddress = ($result | Select-Object Name,IPAddress)
+                $DirectAddresses += $DirectAddress
+            }
+        }
+	$GatewayDnsFormat = ("gv{{0}}-{0}-sb.{1}" -f $Deployment.ToLowerInvariant(), $ParentDomain)
         Foreach ($index in $instances)
         {
             $address = ($GatewayDnsFormat -f $index)


### PR DESCRIPTION
Fix for certain namespaces on clusters using just "ns-" instead of "ns-sb2-". Added check for gateways with "gv" instead of "g"

## Description
<!--
Please add an informative description that covers the changes made by the pull request.

If applicable, reference the bug/issue that this pull request fixes here.
-->

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [x] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [x] If applicable, the public code is properly documented.
- [x] Pull request includes test coverage for the included changes.
- [x] The code builds without any errors.